### PR TITLE
feat: export PATH for krew

### DIFF
--- a/bashrc
+++ b/bashrc
@@ -152,3 +152,6 @@ source <(kubectl completion bash)
 
 complete -F _complete_alias k
 complete -F _complete_alias g
+
+# 2024-06-05 krew for kubectl
+export PATH="${KREW_ROOT:-$HOME/.krew}/bin:$PATH"


### PR DESCRIPTION
kubectl plugin の krew について PATH を追加していないと機能しなかった
（aqua で入れているせい？）
ので追加した