### PR TITLE
fix: use kubecolor wraped kubectl , remove alias make

### DIFF
--- a/bash_aliases
+++ b/bash_aliases
@@ -93,8 +93,9 @@ alias gss='git show --stat'
 alias gst='git status --short --branch'
 alias cr='cd "$(git rev-parse --show-toplevel)"'
 
-# k8s
-alias k='kubectl'
+# k8s use kubecolor
+alias k='kubecolor'
+alias kubectl='kubecolor'
 alias ka='kubectl apply'
 alias kd='kubectl describe'
 alias kdel='kubectl delete'
@@ -107,8 +108,7 @@ alias kgpa='kubectl get pod -A'
 alias kgtn='kubectl get node -o wide; kubectl top node'
 alias kdrainf='kubectl drain --ignore-daemonsets --delete-local-data'
 
-# make
-alias m='make'
+alias stern='kubectl stern'
 
 # terraform
 alias t='terraform'

--- a/bashrc
+++ b/bashrc
@@ -167,3 +167,7 @@ source $HOME/.cargo/env
 # uv
 export PATH="$HOME/.local/bin:$PATH"
 
+# stern install from krew
+# https://github.com/stern/stern?tab=readme-ov-file#completion
+source <(kubectl stern --completion bash)
+complete -o default -F __start_stern kubectl stern


### PR DESCRIPTION
https://github.com/officel/config_aqua/pull/50

kubectl の plugin を krew で管理することにした。
ついでに kubectl のラッパーの kubecolor を使うようにしたのと、
使わなくなった make の alias m を開放した。