### PR TITLE
fix: remove LANG=C from ls alias, add GOPATH

### DIFF
--- a/bash_aliases
+++ b/bash_aliases
@@ -1,7 +1,7 @@
 # .dotfiles/alias
 
 # command
-alias ls='LANG=C ls --group-directories-first'
+alias ls='ls --group-directories-first'
 alias ll='ls -l'
 alias lla='ls -al'
 alias tree='tree --charset unicode -aNI ".git|node_modules|.terraform"'

--- a/bashrc
+++ b/bashrc
@@ -177,3 +177,6 @@ complete -o default -F __start_stern kubectl stern
 
 # volta
 export PATH="$HOME/.volta/bin:$PATH"
+
+# GOPATH
+export PATH="$HOME/go/bin:$PATH"


### PR DESCRIPTION
ターミナルで ls した時に日本語ファイル名が文字化けしてしまっていたので
LANG=C を外した。なぜつけたのか、つけない場合の弊害等が思い出せないので、
思い出すまで外しておくことにする。

--group-directories-first はそのまま。

GOPATH は別のところで設定していて放置していたのを全体反映にするためにもってきていた。
ついでだから入れちゃう。