### PR TITLE
fix: #12 history ignore, task, gr, gst, gau

### DIFF
--- a/bashrc
+++ b/bashrc
@@ -153,7 +153,7 @@ export PATH="${KREW_ROOT:-$HOME/.krew}/bin:$PATH"
 
 # 2024-07-28 history
 export HISTCONTROL=ignoreboth
-export HISTIGNORE=ls:ll:'ls -l':'ls -la':history:pwd:exit:which:w:
+export HISTIGNORE=ls:ll:'ls -l':'ls -la':history:pwd:exit:which:w:task:gr:gst:gau:
 export HISTTIMEFORMAT="%Y-%m-%d %H:%M:%S "
 export HISTSIZE=1000
 export HISTFILESIZE=2000


### PR DESCRIPTION
https://github.com/officel/config_bash/issues/12

`history` に残さないコマンドの追加

`task` 自体はタスクのリスト表示に使っているだけなのでエイリアス呼び出しは残る。
`gr`, `gst`, `gau` （gitのalias）は常に手打ちしているので、残っていなくても問題ないと考えている。