### PR TITLE
feat: ga, gau  git add alias with ignore !!file

### DIFF
--- a/bash_aliases
+++ b/bash_aliases
@@ -73,8 +73,8 @@ alias dcr='docker compose run'
 
 # git
 alias g='git'
-alias ga='git add'
-alias gau='git add -u'
+alias ga='git add ":!\!\!*"'  # :! は除外設定。 !! で始まるファイルを add しない
+alias gau='git add -u ":!\!\!*"'
 alias gb='git branch'
 alias gba='git branch -a'
 alias gcan='git commit --amend --no-edit'


### PR DESCRIPTION
一時的に目立たせておきたいファイルをリポジトリに置いたままリポジトリに追加しないようにする

- ignore してしまうと git status にも出てこない（`__`で始まるファイルは config_git で ignore している）
- 一時的に自分用の注意喚起としてメモを残しておく方法として、`!!`で始まるファイルを add から常に除外する
- 参考 https://git-scm.com/docs/git-add/ja#git-add-codeltpathspecgtcode
- これにより、git status 時に差分として表示されるが、`!!`で始まるファイルは `ga` と `gau` で git add されなくなり、常に差分として（概ね untracking file として）表示される