### PR TITLE
fix: ga, gau use glob

### DIFF
--- a/bash_aliases
+++ b/bash_aliases
@@ -73,8 +73,8 @@ alias dcr='docker compose run'
 
 # git
 alias g='git'
-alias ga='git add ":!\!\!*"'  # :! は除外設定。 !! で始まるファイルを add しない
-alias gau='git add -u ":!\!\!*"'
+alias ga='git add ":!**\!\!*"'  # :! は除外設定。 !! で始まるファイルを add しない
+alias gau='git add -u ":!**\!\!*"'
 alias gb='git branch'
 alias gba='git branch -a'
 alias gcan='git commit --amend --no-edit'


### PR DESCRIPTION
下層ディレクトリにあるファイルが反応しなかった。。。_no
glob で指定して対応できた、はず。

```
config_bash $ touch '!!test'
config_bash $ mkdir gomi
config_bash $ touch 'gomi/!!test'
config_bash $ gst
## HEAD (no branch)
 M bash_aliases
?? !!test
?? gomi/
config_bash $ gau
config_bash $ gst
## HEAD (no branch)
M  bash_aliases
?? !!test
?? gomi/
config_bash $ ga .
config_bash $ gst
## HEAD (no branch)
M  bash_aliases
?? !!test
?? gomi/
config_bash $ gdi
config_bash $ gdc
diff --git a/bash_aliases b/bash_aliases
index 5785755..9547c89 100644
--- a/bash_aliases
+++ b/bash_aliases
@@ -73,8 +73,8 @@ alias dcr='docker compose run'

 # git
 alias g='git'
-alias ga='git add ":!\!\!*"'  # :! は除外設定。 !! で始まるファイルを add しない
-alias gau='git add -u ":!\!\!*"'
+alias ga='git add ":!**\!\!*"'  # :! は除外設定。 !! で始まるファイルを add しない
+alias gau='git add -u ":!**\!\!*"'
 alias gb='git branch'
 alias gba='git branch -a'
 alias gcan='git commit --amend --no-edit'
```