### PR TITLE
feat: new alias tg, tfq, tfva. export XDG_CONFIG_HOME

### DIFF
--- a/bash_aliases
+++ b/bash_aliases
@@ -117,6 +117,7 @@ alias stern='kubectl stern'
 
 # taskfile.dev
 alias t='task'
+alias tg='task --global'
 
 # terraform
 alias tf='terraform'
@@ -128,5 +129,7 @@ alias tfiu='terraform init --upgrade'
 alias tfir='terraform init -reconfigure'
 alias tfo='terraform output'
 alias tfp='terraform plan'
+alias tfq='terraform query'
 alias tfs='terraform state'
 alias tfv='terraform version'
+alias tfva='terraform validate'

--- a/bashrc
+++ b/bashrc
@@ -97,6 +97,9 @@ alias alert='notify-send --urgency=low -i "$([ $? = 0 ] && echo terminal || echo
 # ~/.bash_aliases, instead of adding them here directly.
 # See /usr/share/doc/bash-doc/examples in the bash-doc package.
 
+# 環境変数 XDG_CONFIG_HOME が設定されていないとうまく機能しないやつがいる
+export XDG_CONFIG_HOME=${XDG_CONFIG_HOME:-$HOME/.config}
+
 if [ -f ${XDG_CONFIG_HOME:-$HOME/.config}/bash/bash_aliases ]; then
     .   ${XDG_CONFIG_HOME:-$HOME/.config}/bash/bash_aliases
 fi


### PR DESCRIPTION
- task のグローバルを配置して管理するようにしたので、どこからでも呼びやすいように tg とした
- terraform validate は VS Code にまかせてたんだけど、vi 使った時とか漏れるので呼べるようにした
- terraform query は terraform v1.14.0 がリリースされたら使う（v.14.0-beta1でテスト済）
- XDG_CONFIG_HOME って環境変数的には要らないと思うんだけど、とりあえず。。。